### PR TITLE
Update pipeline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,35 +14,74 @@ jobs:
           - master
           - release
     steps:
+      - name: Install jq
+        run: sudo apt-get update && sudo apt-get install -y jq
+
+      - name: Check for new release
+        id: check_release
+        run: |
+          # Fetch the latest release information from the target repository
+          RESPONSE=$(curl --silent --fail "https://api.github.com/repos/gchq/CyberChef/releases/latest")
+  
+          if [ $? -ne 0 ]; then
+            echo "Failed to fetch the latest release information."
+            exit 1
+          fi
+  
+          # Extract the "published_at" field using jq
+          PUBLISHED_AT=$(echo "$RESPONSE" | jq -r '.published_at')
+  
+          # Convert the published_at to Unix timestamp
+          PUBLISHED_TIMESTAMP=$(date -d "$PUBLISHED_AT" +%s)
+  
+          # Get the current time and convert it to Unix timestamp
+          CURRENT_TIMESTAMP=$(date +%s)
+  
+          # Calculate the difference in seconds
+          TIME_DIFF=$(expr "$CURRENT_TIMESTAMP" - "$PUBLISHED_TIMESTAMP")
+  
+          # If the difference is less than 86400 seconds (24 hours), proceed with the next steps
+          if [ $TIME_DIFF -le 86400 ]; then
+            echo "New release detected. Proceeding with the next steps."
+            echo "proceed=true" >> $GITHUB_OUTPUT
+          else
+            echo "No new release in the last 24 hours."
+            echo "proceed=false" >> $GITHUB_OUTPUT
+          fi
+      
       - name: Set up QEMU
+        if: steps.check_release.outputs.proceed == 'true'
         uses: docker/setup-qemu-action@v2
 
       - name: Set up Docker Buildx
+        if: steps.check_release.outputs.proceed == 'true'
         uses: docker/setup-buildx-action@v2
 
       - name: Login to DockerHub
+        if: steps.check_release.outputs.proceed == 'true'
         uses: docker/login-action@v2
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Set version for master
-        if: ${{ matrix.version == 'master' }}
+        if: matrix.version == 'master' && steps.check_release.outputs.proceed == 'true'
         run: echo 'VERSION=master' >> $GITHUB_ENV
 
       - name: Set tag for master
-        if: ${{ matrix.version == 'master' }}
+        if: matrix.version == 'master' && steps.check_release.outputs.proceed == 'true'
         run: echo "TAG=docker.io/mpepping/cyberchef:latest" >> $GITHUB_ENV
 
       - name: Set version for release
-        if: ${{ matrix.version == 'release' }}
+        if: matrix.version == 'release' && steps.check_release.outputs.proceed == 'true'
         run: curl -s https://api.github.com/repos/gchq/CyberChef/releases/latest | grep '"tag_name":' | sed -E 's/.*"([^"]+)".*/VERSION=\1/' >> $GITHUB_ENV
 
       - name: Set tag for release
-        if: ${{ matrix.version == 'release' }}
+        if: matrix.version == 'release' && steps.check_release.outputs.proceed == 'true'
         run: echo "TAG=docker.io/mpepping/cyberchef:${VERSION}" >> $GITHUB_ENV
 
       - name: Build and push
+        if: steps.check_release.outputs.proceed == 'true' 
         timeout-minutes: 720
         uses: docker/build-push-action@v4
         with:


### PR DESCRIPTION
Hey,
I updated the pipeline so the pipeline only continues if there was a release in the last 24 hours in the main repo. I myself use the docker-image in my home-cluster and I use diun which sends me notifications on a new release of a docker-image. Right now I get this notification every day, which is annoying.
Also I saw the opened issue #24. So I thought I implement it myself.


I hope this helps. Let me know what you think.

Kind   regards,
Michael