### PR TITLE
Fix make shell

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,4 +23,4 @@ stop: ## Stop the container
 	docker rm -f cyberchef
 
 shell: ## Creates a shell inside the container for debug purposes
-	docker run -it --rm $(APP_NAME):latest bash
+	docker run -it --rm $(APP_NAME):latest /bin/sh


### PR DESCRIPTION
Bash is not present in the container, causing `make shell` to error. Updated `make shell` to use `/bin/sh` within the container.

Spotted this one when checking the container's curl version in the other PR to verify the ipv6 healthcheck :)